### PR TITLE
fix: Full load/save  all viewsettings from preset files

### DIFF
--- a/packages/midi-bricks-electron/public/electron.js
+++ b/packages/midi-bricks-electron/public/electron.js
@@ -186,12 +186,8 @@ function onSaveFileDialog(event, arg) {
       defaultPath: app.getPath('userData'),
       filters: [
         {
-          name: 'json',
-          extensions: ['json']
-        },
-        {
-          name: 'javascript',
-          extensions: ['js']
+          name: 'midi-bricks-preset',
+          extensions: ['json', 'js']
         }
       ]
     },
@@ -222,12 +218,8 @@ function onOpenFileDialog(event, arg) {
       properties: ['openFile'],
       filters: [
         {
-          name: 'javascript',
-          extensions: ['js']
-        },
-        {
-          name: 'json',
-          extensions: ['json']
+          name: 'midi-bricks-preset',
+          extensions: ['json', 'js']
         }
       ]
     },
@@ -243,8 +235,7 @@ function onOpenFileDialog(event, arg) {
             appSettings = persistAppSettings(arg)
             event.sender.send('open-file-dialog-reply', stuff)
             log.info(
-              'Object loaded: ',
-              stuff.content.viewSettings || 'nothing found'
+              'Object loaded: '              
             )
             return data
           },

--- a/packages/midi-bricks/src/App.jsx
+++ b/packages/midi-bricks/src/App.jsx
@@ -27,7 +27,6 @@ App.propTypes = {
   initApp: PropTypes.func
 }
 
-console.log('we have a new app in here')
 function App(props) {
   const classes = makeStyles(styles, { withTheme: true })()
   const { actions = {}, initApp = () => {} } = props
@@ -91,8 +90,8 @@ async function onFileChange(
   actions.deleteFooterPages()
   window.localStorage.clear()
 
-  // Prepare foooterpages flush
-  actions.loadFile({ presetName, content }) 
+  // will load content to slider-list-reducer
+  actions.loadFile({ presetName, content })
 
   const {
     viewSettings,
@@ -113,10 +112,15 @@ async function onFileChange(
       }
     }
   }
-  sliderList &&
-    actions.updateViewSettings({
+
+  // Will load content to view-settings-reducer
+  sliderList && Array.isArray(sliderList)
+    ? actions.updateViewSettings({
       viewSettings: { ...viewSettings, availableDrivers: drivers },
       sliderList: sliderList
+    })
+    : actions.updateViewSettings({
+      viewSettings: { ...viewSettings, availableDrivers: drivers }
     })
   await initApp()
   actions.togglePage({

--- a/packages/midi-bricks/src/components/midi-settings/elements/ValueInput.jsx
+++ b/packages/midi-bricks/src/components/midi-settings/elements/ValueInput.jsx
@@ -13,7 +13,7 @@ ValueInput.propTypes = {
   name: PropTypes.string,
   onChange: PropTypes.func,
   toolTip: PropTypes.string,
-  value: PropTypes.number,
+  value: PropTypes.string,
   isDisabled: PropTypes.bool
 }
 

--- a/packages/midi-bricks/src/reducers/slider-list.js
+++ b/packages/midi-bricks/src/reducers/slider-list.js
@@ -465,7 +465,7 @@ export const reducers = {
     const {
       payload: {
         presetName,
-        content: { viewSettings, sliders: { sliderList: sliderListOld = [] } = {} } = {}
+        content: { sliders: { sliderList: sliderListOld = [] } = {} } = {}
       } = {}
     } = action
 
@@ -502,9 +502,6 @@ export const reducers = {
       sliderList,
       presetName,
       sliderListBackup: sliderList,
-      viewSettings: {
-        ...viewSettings
-      }
     }
   },
   [ActionTypeSliderList.CHANGE_LIST_ORDER](state, action) {

--- a/packages/midi-bricks/src/reducers/view-settings.js
+++ b/packages/midi-bricks/src/reducers/view-settings.js
@@ -138,6 +138,7 @@ export const reducers = {
   [ActionTypeViewSettings.UPDATE_VIEW_SETTINGS](state = initState, action) {
     const {
       sliderList,
+      viewSettings,
       viewSettings: { availableDrivers } = {}
     } = action.payload
 
@@ -159,11 +160,11 @@ export const reducers = {
     const newPages = oldPages && oldPages.length > 0 ? oldPages : extractedPages
     let footerState = null
     if (newItemToTake) {
-      footerState = Object.assign({}, state, {
+      footerState = Object.assign({}, state, viewSettings, {
         footerPages: [...newPages, newItemToTake]
       })
     } else {
-      footerState = Object.assign({}, state, {
+      footerState = Object.assign({}, state, viewSettings, {
         footerPages: newPages
       })
     }


### PR DESCRIPTION
# Pull Request:
## Does the issue occur in the electron-app or the web-app?
  midi-bricks-electron
  midi-bricks-web-app


## Can you determine, which version was used?
Version: v1.1.90

## Describe the bug
If some view setting (them change for example) was changed and saved, it was not reloaded after saving. 

Desktop Version (please complete the following information):
Operating System: Win 10 64bit or mac 


